### PR TITLE
Feat/subcharts

### DIFF
--- a/src/components/PageOne/InfoContainer.js
+++ b/src/components/PageOne/InfoContainer.js
@@ -17,7 +17,7 @@ class InfoContainer extends Component {
     }
 
     onChange = (event) => {
-        event.target.type === 'number' || event.target.type === 'range'
+        event.target.type === 'number'
             ? this.setState({ [event.target.name]: parseInt(event.target.value) })
             : this.setState({ [event.target.name]: event.target.value })
     }

--- a/src/components/PageOne/MarketInfoForm.js
+++ b/src/components/PageOne/MarketInfoForm.js
@@ -8,7 +8,7 @@ export default function MarketInfoForm(props) {
                 <div className="form-row">
                     <div className="slider">
                         <label><b>How price sensitive is your market?</b></label>
-                        <input type="range" min={-2} max={0} name="elasticity" value={props.values.elasticity} onChange={props.onChange} />
+                        <input type="range" min="-2" max="0" step="0.1" name="elasticity" value={props.values.elasticity} onChange={props.onChange} style={{direction: 'rtl'}} />
                         {props.values.elasticity}
                     </div>
                     <div className="slider">

--- a/src/components/Results/MainChart.js
+++ b/src/components/Results/MainChart.js
@@ -25,7 +25,7 @@ export default class MainChart extends Component {
                                         5, 
                                         "profit",
                                         "cumulative",
-                                        true
+                                        this.props.cumulative
                                     ).cumulative,
                                     backgroundColor: "rgba(101, 188, 162, 0.3)",
                                     pointBackgroundColor:  "rgba(101, 188, 162, 1)",
@@ -34,13 +34,13 @@ export default class MainChart extends Component {
                                     label: "Profit after tax", //companyInfo, taxScope, taxInfo, emissionsInput, years, profit, cumulative, isCumulative
                                     data: dataGraphProfitAT(
                                         this.props.companyData, 
-                                        {scope1: true, scope2: true, scope3: true,}, 
+                                        this.props.taxScope, 
                                         this.props.taxInfo,
                                         this.props.emissionData,
                                         5,
                                         "profitAT",
                                         "cumulativeProfitAT",
-                                        true
+                                        this.props.cumulative
                                     ).cumulative,
                                     backgroundColor: "rgba(69, 168, 72, 0.3)",
                                     pointBackgroundColor:  "rgba(69, 168, 72, 1)",

--- a/src/components/Results/MainChart.js
+++ b/src/components/Results/MainChart.js
@@ -27,11 +27,11 @@ export default class MainChart extends Component {
                                         "cumulative",
                                         this.props.cumulative
                                     ).cumulative,
-                                    backgroundColor: "rgba(101, 188, 162, 0.3)",
+                                    backgroundColor: "rgba(101, 188, 162, 0.4)",
                                     pointBackgroundColor:  "rgba(101, 188, 162, 1)",
                                 },
                                 {
-                                    label: "Profit after tax", //companyInfo, taxScope, taxInfo, emissionsInput, years, profit, cumulative, isCumulative
+                                    label: "Profit after tax",
                                     data: dataGraphProfitAT(
                                         this.props.companyData, 
                                         this.props.taxScope, 
@@ -42,7 +42,7 @@ export default class MainChart extends Component {
                                         "cumulativeProfitAT",
                                         this.props.cumulative
                                     ).cumulative,
-                                    backgroundColor: "rgba(69, 168, 72, 0.3)",
+                                    backgroundColor: "rgba(69, 168, 72, 0.4)",
                                     pointBackgroundColor:  "rgba(69, 168, 72, 1)",
                                     fill: true,
                                 }

--- a/src/components/Results/MainChart.js
+++ b/src/components/Results/MainChart.js
@@ -26,7 +26,7 @@ export default class MainChart extends Component {
                                         "profit",
                                         "cumulative",
                                         this.props.cumulative
-                                    ).cumulative,
+                                    ),
                                     backgroundColor: "rgba(101, 188, 162, 0.4)",
                                     pointBackgroundColor:  "rgba(101, 188, 162, 1)",
                                 },
@@ -41,7 +41,7 @@ export default class MainChart extends Component {
                                         "profitAT",
                                         "cumulativeProfitAT",
                                         this.props.cumulative
-                                    ).cumulative,
+                                    ),
                                     backgroundColor: "rgba(69, 168, 72, 0.4)",
                                     pointBackgroundColor:  "rgba(69, 168, 72, 1)",
                                     fill: true,

--- a/src/components/Results/ResultsContainer.js
+++ b/src/components/Results/ResultsContainer.js
@@ -11,13 +11,17 @@ import EmissionsOptionsContainer from './EmissionsOptionsContainer'
 class ResultsContainer extends Component {
     state = {
         euroPerTon: 50, // euros
-        taxGrowth: 5.5, // percentage
+        taxGrowth: 5.5, // percentage,
+        cumulative: true,
+        scope1Taxable: true,
+        scope2Taxable: true,
+        scope3Taxable: true
     }
 
     onChange = (event) => {
-        this.setState({
-            [event.target.name]: event.target.value
-        })
+        event.target.type === 'checkbox'
+            ? this.setState({ [event.target.name]: !this.state[event.target.name] })
+            : this.setState({ [event.target.name]: event.target.value })
     }
 
     render() {
@@ -30,8 +34,28 @@ class ResultsContainer extends Component {
                     <EmissionsOptionsContainer emissionsData={this.props.emissionsData} />
                 </div>
                 <div className="chart-container">
-                    <MainChart taxInfo={this.state} companyData={this.props.companyData} emissionData={this.props.emissionData} />
-                    <SubCharts taxInfo={this.state} companyData={this.props.companyData} emissionData={this.props.emissionData} />
+                    <MainChart 
+                        taxInfo={this.state} 
+                        companyData={this.props.companyData} 
+                        emissionData={this.props.emissionData}
+                        cumulative={this.state.cumulative}
+                        taxScope={{
+                            scope1: this.state.scope1Taxable, 
+                            scope2: this.state.scope2Taxable,
+                            scope3: this.state.scope3Taxable,
+                        }} 
+                    />
+                    <SubCharts 
+                        taxInfo={this.state} 
+                        companyData={this.props.companyData} 
+                        emissionData={this.props.emissionData}
+                        cumulative={this.state.cumulative}
+                        taxScope={{
+                            scope1: this.state.scope1Taxable, 
+                            scope2: this.state.scope2Taxable,
+                            scope3: this.state.scope3Taxable,
+                        }}  
+                    />
                 </div>
             </div>
         )

--- a/src/components/Results/SubCharts.js
+++ b/src/components/Results/SubCharts.js
@@ -27,7 +27,7 @@ export default class SubCharts extends Component {
                                         "cumulativeTax", 
                                         this.props.cumulative
                                     ).cumulative,
-                                    backgroundColor: "rgba(101, 188, 162, 0.3)",
+                                    backgroundColor: "rgba(101, 188, 162, 0.5)",
                                     pointBackgroundColor:  "rgba(101, 188, 162, 1)",
                                 },
                             ]
@@ -53,7 +53,7 @@ export default class SubCharts extends Component {
                                         "cumulativeEmissions", 
                                         this.props.cumulative
                                     ).cumulative,
-                                    backgroundColor: "rgba(101, 188, 162, 0.3)",
+                                    backgroundColor: "rgba(101, 188, 162, 0.5)",
                                     pointBackgroundColor:  "rgba(101, 188, 162, 1)",
                                 },
                             ]

--- a/src/components/Results/SubCharts.js
+++ b/src/components/Results/SubCharts.js
@@ -26,7 +26,7 @@ export default class SubCharts extends Component {
                                         "totalTax", 
                                         "cumulativeTax", 
                                         this.props.cumulative
-                                    ).cumulative,
+                                    ),
                                     backgroundColor: "rgba(101, 188, 162, 0.4)",
                                     pointBackgroundColor:  "rgba(101, 188, 162, 1)",
                                 },
@@ -52,7 +52,7 @@ export default class SubCharts extends Component {
                                         "taxableEmissions", 
                                         "cumulativeEmissions", 
                                         this.props.cumulative
-                                    ).cumulative,
+                                    ),
                                     backgroundColor: "rgba(101, 188, 162, 0.5)",
                                     pointBackgroundColor:  "rgba(101, 188, 162, 1)",
                                 },

--- a/src/components/Results/SubCharts.js
+++ b/src/components/Results/SubCharts.js
@@ -27,7 +27,7 @@ export default class SubCharts extends Component {
                                         "cumulativeTax", 
                                         this.props.cumulative
                                     ).cumulative,
-                                    backgroundColor: "rgba(101, 188, 162, 0.5)",
+                                    backgroundColor: "rgba(101, 188, 162, 0.4)",
                                     pointBackgroundColor:  "rgba(101, 188, 162, 1)",
                                 },
                             ]

--- a/src/components/Results/SubCharts.js
+++ b/src/components/Results/SubCharts.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react'
 import {Line} from 'react-chartjs-2'
 import {optionsEuro, options} from './chartOptions'
-import {dataGraphCO2Tax} from '../../formulas/calculateProfit/calculateProfit'
+import {dataGraphCO2Tax, dataGraphTaxableEmissions} from '../../formulas/calculateProfit/calculateProfit'
 
 export default class SubCharts extends Component {
+    
     render() {
         return (
             <div className="subcharts-container">
@@ -16,7 +17,16 @@ export default class SubCharts extends Component {
                             [
                                 {
                                     label: "Total CO2 tax",
-                                    data: [],
+                                    data: dataGraphCO2Tax(
+                                        this.props.companyData, 
+                                        this.props.taxScope, 
+                                        this.props.taxInfo, 
+                                        this.props.emissionData, 
+                                        5, 
+                                        "totalTax", 
+                                        "cumulativeTax", 
+                                        this.props.cumulative
+                                    ).cumulative,
                                     backgroundColor: "rgba(101, 188, 162, 0.3)",
                                     pointBackgroundColor:  "rgba(101, 188, 162, 1)",
                                 },
@@ -33,13 +43,16 @@ export default class SubCharts extends Component {
                             [
                                 {
                                     label: "Taxable emissions",
-                                    data: [
-                                        1200000*this.props.taxInfo.euroPerTon,
-                                        1300000*this.props.taxInfo.euroPerTon,
-                                        1400000*this.props.taxInfo.euroPerTon,
-                                        1500000*this.props.taxInfo.euroPerTon,
-                                        1600000*this.props.taxInfo.euroPerTon
-                                    ],
+                                    data: dataGraphTaxableEmissions(
+                                        this.props.companyData, 
+                                        this.props.taxScope, 
+                                        this.props.taxInfo, 
+                                        this.props.emissionData, 
+                                        5, 
+                                        "taxableEmissions", 
+                                        "cumulativeEmissions", 
+                                        this.props.cumulative
+                                    ).cumulative,
                                     backgroundColor: "rgba(101, 188, 162, 0.3)",
                                     pointBackgroundColor:  "rgba(101, 188, 162, 1)",
                                 },

--- a/src/components/Results/TaxOptions.js
+++ b/src/components/Results/TaxOptions.js
@@ -1,6 +1,10 @@
 import React from 'react'
 
 export default function TaxOptions(props) {
+    const growthValues = []
+    for(let i = 0.5; i <= 6.5; i += 0.5) {
+        growthValues.push(i)
+    }
     return (
         <div className="tax-options">
             <h2>CO2 Tax</h2>
@@ -12,7 +16,7 @@ export default function TaxOptions(props) {
             <div className="tax-growth-container">
                 <p>Tax price growth p/y</p>
                 <select name="taxGrowth" onChange={props.onChange} >
-                    <option value={props.values.taxGrowth}>5.5%</option>
+                    {growthValues.map(val => <option value={val} key={val}>{val.toFixed(1)}%</option>)}
                 </select>
             </div>
         </div>

--- a/src/components/Results/chartOptions.js
+++ b/src/components/Results/chartOptions.js
@@ -25,8 +25,6 @@ export const options = {
     legend: {
         display: true,
         usePointStyle: true,
-        pointStyle: 'line'
-        
     },
     scales: {
         yAxes: [{
@@ -41,3 +39,21 @@ export const options = {
         }]
     }
 }
+
+// export const plugins = [{
+//     beforeRender: function (x, options) {
+//         var c = x.chart
+//         var dataset = x.data.datasets[0];
+//         var yScale = x.scales['y-axis-0'];
+//         var yPos = yScale.getPixelForValue(0);
+
+//         var gradientFill = c.ctx.createLinearGradient(0, 0, 0, c.height);
+//         gradientFill.addColorStop(0, 'green');
+//         gradientFill.addColorStop(yPos / c.height - 0.01, 'green');
+//         gradientFill.addColorStop(yPos / c.height + 0.01, 'red');
+//         gradientFill.addColorStop(1, 'red');
+
+//         var model = x.data.datasets[0]._meta[Object.keys(dataset._meta)[0]].dataset._model;
+//         model.backgroundColor = gradientFill;
+//     }
+// }]

--- a/src/components/Results/chartOptions.js
+++ b/src/components/Results/chartOptions.js
@@ -10,6 +10,9 @@ export const optionsEuro = {
         yAxes: [{
             ticks: {
                 callback: function(value, index, values) {
+                    value = value.toString();
+                    value = value.split(/(?=(?:...)*$)/);
+                    value = value.join(',');
                     return '€' + value
                 }
             }
@@ -24,5 +27,17 @@ export const options = {
         usePointStyle: true,
         pointStyle: 'line'
         
+    },
+    scales: {
+        yAxes: [{
+            ticks: {
+                callback: function(value, index, values) {
+                    value = value.toString();
+                    value = value.split(/(?=(?:...)*$)/);
+                    value = value.join(',');
+                    return value
+                }
+            }
+        }]
     }
 }

--- a/src/formulas/calculateProfit/calculateProfit.js
+++ b/src/formulas/calculateProfit/calculateProfit.js
@@ -123,7 +123,7 @@ const createArrays = (profitTable, varNameDiscrete, varNameCumulative, years, is
         cumulative = [...cumulative, profitTable[year][varNameCumulative]]
     })
 
-    const graphData = isCumulative ? { cumulative } : { profit }
+    const graphData = isCumulative ? cumulative : profit
 
     return graphData
 }

--- a/src/formulas/calculateProfit/calculateProfit.js
+++ b/src/formulas/calculateProfit/calculateProfit.js
@@ -141,8 +141,6 @@ export const dataGraphProfitNT = (companyInfo, years, profit, cumulative, isCumu
 export const dataGraphProfitAT = (companyInfo, taxScope, taxInfo, emissionsInput, years, profit, cumulative, isCumulative) => {
     taxInfo.euroPerTon = parseInt(taxInfo.euroPerTon)
     const profitTable = calculateProfitWithTaxes(companyInfo, taxScope, taxInfo, emissionsInput, years, isCumulative)
-    // console.log('profittable', profitTable)
-    // console.log('profittable vars', companyInfo, taxScope, taxInfo, emissionsInput, years, isCumulative)
     const graphData = createArrays(profitTable, profit, cumulative, years, isCumulative)
     return graphData
 }

--- a/src/reducers/pageOneInput.js
+++ b/src/reducers/pageOneInput.js
@@ -1,7 +1,12 @@
 import {SUBMIT_INPUT_ONE} from '../actions/submitInput'
 
 const initialState = {
-    industry: "Building materials including wood"
+    industry: "Building materials including wood",
+    turnover: 20000000000,
+    turnoverGrowth: 100, 
+    profitMargin: 10, 
+    elasticity: -0.4, 
+    taxToCustomer: 100, 
 };
 
 export default (state = initialState, action = {}) => {

--- a/src/reducers/pageTwoInput.js
+++ b/src/reducers/pageTwoInput.js
@@ -1,6 +1,14 @@
 import {SUBMIT_INPUT_TWO} from '../actions/submitInput'
 
-const initialState = null;
+const initialState = {
+    emissionsKnown: "no",
+    S1emissions: 701020, // tons CO2
+    S1reductionTarget: 100, // percentage
+    S2emissions: 701020, // tons CO2
+    S2reductionTarget: 0, // percentage
+    S3emissions: 12618360, // tons CO2
+    S3reductionTarget: 100, // percentage
+};
 
 export default (state = initialState, action = {}) => {
     switch(action.type) {


### PR DESCRIPTION
The tax per year chart now functions as it should, the other chart still requires some changes to the returned values from its respective calculations. 

- Reformatted the Y axis labels on the charts to make them easier to read.
- Fixed an issue where the calculations for the chart data were not returning an array.
- Increased the opacity value on the chart fill colors.
- Increased the number of available tax growth values.