### PR TITLE
Feat/antd components

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,0 +1,16 @@
+const { override, fixBabelImports, addLessLoader } = require('customize-cra');
+
+module.exports = override(
+    fixBabelImports('import', {
+        libraryName: 'antd',
+        libraryDirectory: 'es',
+        style: true,
+    }),
+    addLessLoader({
+        javascriptEnabled: true,
+        modifyVars: { // Modify theme LESS theme below
+            '@primary-color': '#45A848',
+            '@heading-color': '#40809C',
+        },
+    }),
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2966,6 +2966,15 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-import": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import/-/babel-plugin-import-1.11.2.tgz",
+      "integrity": "sha512-Ja3LvQZEMqwxo3QkxRwq4pnl4F18kzd/eTbMFOP6MKtSecPajSXE22fZQcfBr5OQ/jWEwZY3PulIvrlDABNIEA==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/runtime": "^7.0.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
@@ -4693,6 +4702,11 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "clone-deep": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
@@ -5325,6 +5339,14 @@
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",
       "integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg=="
+    },
+    "customize-cra": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/customize-cra/-/customize-cra-0.2.12.tgz",
+      "integrity": "sha512-kTNJtB35ZxHO8E3wbHNNkngQHH4u8uD8zAK4hQ29qSRRyLe1dln3k678GeyWd9TAERIqLq/5uJR37Y0P+lJLRA==",
+      "requires": {
+        "lodash.flow": "^3.5.0"
+      }
     },
     "cyclist": {
       "version": "0.2.2",
@@ -7586,6 +7608,12 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
+    "image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "optional": true
+    },
     "immer": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
@@ -9317,6 +9345,62 @@
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
       "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
     },
+    "less": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/less/-/less-3.9.0.tgz",
+      "integrity": "sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==",
+      "requires": {
+        "clone": "^2.1.2",
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "mime": "^1.4.1",
+        "mkdirp": "^0.5.0",
+        "promise": "^7.1.1",
+        "request": "^2.83.0",
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "optional": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "optional": true,
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "optional": true
+        }
+      }
+    },
+    "less-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-5.0.0.tgz",
+      "integrity": "sha512-bquCU89mO/yWLaUq0Clk7qCsKhsF/TZpJUzETRvJa9KSVEL9SO3ovCvdEHISBhrC81OwC8QSVX7E0bzElZj9cg==",
+      "requires": {
+        "clone": "^2.1.1",
+        "loader-utils": "^1.1.0",
+        "pify": "^4.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        }
+      }
+    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -9441,6 +9525,11 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "lodash.flow": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
+      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -12353,6 +12442,23 @@
         "raf": "3.4.1",
         "regenerator-runtime": "0.13.2",
         "whatwg-fetch": "3.0.0"
+      }
+    },
+    "react-app-rewired": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.3.tgz",
+      "integrity": "sha512-NXC2EsQrnEMV7xD70rHcBq0B4PSEzjY/K2m/e+GRgit2jZO/uZApnpCZSKvIX2leLRN69Sqf2id0VXZ1F62CDw==",
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "dotenv": "^6.2.0",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "react-chartjs-2": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,14 @@
   "dependencies": {
     "antd": "^3.18.2",
     "babel-cli": "^6.26.0",
+    "babel-plugin-import": "^1.11.2",
     "babel-preset-es2015": "^6.24.1",
     "chart.js": "^2.8.0",
+    "customize-cra": "^0.2.12",
+    "less": "^3.9.0",
+    "less-loader": "^5.0.0",
     "react": "^16.8.6",
+    "react-app-rewired": "^2.1.3",
     "react-chartjs-2": "^2.7.6",
     "react-dom": "^16.8.6",
     "react-redux": "^7.0.3",
@@ -19,9 +24,9 @@
     "superagent": "^5.0.5"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/components/PageOne/MarketInfoForm.js
+++ b/src/components/PageOne/MarketInfoForm.js
@@ -16,7 +16,7 @@ export default function MarketInfoForm(props) {
                         <Slider
                             value={props.values.elasticity} 
                             onChange={e => props.onChange(e, 'elasticity')}
-                            min={-2}
+                            min={-4}
                             max={0}
                             step={0.1}
                         />

--- a/src/components/PageTwo/EmissionsContainer.js
+++ b/src/components/PageTwo/EmissionsContainer.js
@@ -5,6 +5,7 @@ import {calculateEmissions} from '../../formulas/calculateEmissions/calculateEmi
 import './EmissionsContainer.css'
 import { connect } from 'react-redux';
 import {submitInputTwo} from '../../actions/submitInput'
+import {Radio, Button} from 'antd'
 
 class EmissionsContainer extends Component {
     state = {
@@ -39,9 +40,9 @@ class EmissionsContainer extends Component {
         }
     }
 
-    onChange = (event) => {
+    onChange = (data, target) => {
         this.setState({
-            [event.target.name]: event.target.value
+            [target]: data
         })
     }
 
@@ -57,11 +58,14 @@ class EmissionsContainer extends Component {
                 <div className="knows-emissions">
                     <h2>Company CO2 Emissions</h2>
                     Do you know your company CO2 emissions? 
-                    <select value={this.state.emissionsKnown} name="emissionsKnown" onChange={this.onEmissionsKnownChange}>
-                        <option value=""></option>
-                        <option value="yes">Yes</option>
-                        <option value="no">No</option>
-                    </select>
+                    <Radio.Group 
+                        value={this.state.emissionsKnown} 
+                        onChange={this.onEmissionsKnownChange}
+                        style={{ marginLeft: '5%' }}
+                    >
+                        <Radio value="yes">Yes</Radio>
+                        <Radio value="no">No</Radio>
+                    </Radio.Group>
                 </div>
                 {this.state.emissionsKnown && 
                     <div className="form-container">

--- a/src/components/PageTwo/EmissionsForm.js
+++ b/src/components/PageTwo/EmissionsForm.js
@@ -1,4 +1,12 @@
 import React from 'react'
+import {Select} from 'antd'
+import NumericInput from '../Utils/NumericInput'
+
+const Option = Select.Option
+
+const rtSelect = {
+    width: '80px'
+}
 
 const percs = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
 
@@ -17,42 +25,75 @@ export default function EmissionsForm(props) {
                     <td>Scope 1 - Direct emissions</td>
                     <td>
                         {props.values.emissionsKnown === 'yes'
-                            ?<input type="number" name="S1emissions" value={props.values.S1emissions} onChange={props.onChange}/>
-                            :<input type="number" name="S1emissions" value={props.values.S1emissions} disabled />
+                            ?<NumericInput 
+                                maxLength={25} 
+                                value={props.values.S1emissions} 
+                                onChange={e => props.onChange(e, 'S1emissions')} 
+                            />
+                            :<NumericInput 
+                                value={props.values.S1emissions} 
+                                disabled
+                            />
                         }
                     </td>
                     <td>
-                        <select name="S1reductionTarget" onChange={props.onChange}>
-                            {percs.map(val => <option value={val} key={val}>{val}%</option> )}
-                        </select>
+                        <Select 
+                            style={rtSelect} 
+                            defaultValue="0" 
+                            onChange={e => props.onChange(e, 'S1reductionTarget')}
+                        >
+                            {percs.map(val => <Option value={val} key={val}>{val}%</Option> )}
+                        </Select>
                     </td>
                 </tr>
                 <tr>
                     <td>Scope 2 - Direct emissions</td>
                     <td>
                         {props.values.emissionsKnown === 'yes'
-                            ?<input type="number" name="S2emissions" value={props.values.S2emissions} onChange={props.onChange}/>
-                            :<input type="number" name="S2emissions" value={props.values.S2emissions}  disabled />
+                            ?<NumericInput 
+                                maxLength={25} 
+                                value={props.values.S2emissions} 
+                                onChange={e => props.onChange(e, 'S2emissions')} 
+                            />
+                            :<NumericInput 
+                                value={props.values.S2emissions} 
+                                disabled
+                            />
                         }
                     </td>
                     <td>
-                        <select name="S2reductionTarget" onChange={props.onChange}>
-                            {percs.map(val => <option value={val} key={val}>{val}%</option> )}
-                        </select>
+                        <Select 
+                            style={rtSelect} 
+                            defaultValue="0" 
+                            onChange={e => props.onChange(e, 'S2reductionTarget')}
+                        >
+                            {percs.map(val => <Option value={val} key={val}>{val}%</Option> )}
+                        </Select>
                     </td>
                 </tr>
                 <tr>
                     <td>Scope 3 - Indirect emissions</td>
                     <td>
                         {props.values.emissionsKnown === 'yes'
-                            ?<input type="number" name="S3emissions" value={props.values.S3emissions} onChange={props.onChange}/>
-                            :<input type="number" name="S3emissions" value={props.values.S3emissions}  disabled />
+                            ?<NumericInput 
+                                maxLength={25} 
+                                value={props.values.S3emissions} 
+                                onChange={e => props.onChange(e, 'S3emissions')} 
+                            />
+                            :<NumericInput 
+                                value={props.values.S3emissions} 
+                                disabled
+                            />
                         }
                     </td>
                     <td>
-                        <select name="S3reductionTarget" onChange={props.onChange}>
-                            {percs.map(val => <option value={val} key={val}>{val}%</option> )}
-                        </select>
+                        <Select 
+                            style={rtSelect} 
+                            defaultValue="0" 
+                            onChange={e => props.onChange(e, 'S3reductionTarget')}
+                        >
+                            {percs.map(val => <Option value={val} key={val}>{val}%</Option> )}
+                        </Select>
                     </td>
                 </tr>
             </tbody>

--- a/src/formulas/calculateProfit/calculateProfit.js
+++ b/src/formulas/calculateProfit/calculateProfit.js
@@ -181,10 +181,3 @@ export const dataGraphTaxableEmissions = (companyInfo, taxScope, taxInfo, emissi
 // console.log(dataGraphCO2Tax(companyInfo, taxScope, taxInfo, emissionsInput, 5, "totalTax", "cumulativeTax", false))
 // console.log(dataGraphTaxableEmissions(companyInfo, taxScope, taxInfo, emissionsInput, 5, "taxableEmissions", "cumulativeEmissions", true))
 // console.log(dataGraphTaxableEmissions(companyInfo, taxScope, taxInfo, emissionsInput, 5, "taxableEmissions", "cumulativeEmissions", false))
-
-console.log(dataGraphTaxableEmissions(companyInfo, taxScope, taxInfo, emissionsInput, 5, "scope1", "scope1Cumulative", true))
-console.log(dataGraphTaxableEmissions(companyInfo, taxScope, taxInfo, emissionsInput, 5, "scope1", "scope1Cumulative", false))
-console.log(dataGraphTaxableEmissions(companyInfo, taxScope, taxInfo, emissionsInput, 5, "scope2", "scope2Cumulative", true))
-console.log(dataGraphTaxableEmissions(companyInfo, taxScope, taxInfo, emissionsInput, 5, "scope2", "scope2Cumulative", false))
-console.log(dataGraphTaxableEmissions(companyInfo, taxScope, taxInfo, emissionsInput, 5, "scope3", "scope3Cumulative", true))
-console.log(dataGraphTaxableEmissions(companyInfo, taxScope, taxInfo, emissionsInput, 5, "scope3", "scope3Cumulative", false))


### PR DESCRIPTION
Use `npm i` to install the added dependencies.

- Added an easy way to override some react webpack configs. This allows for the antd theme to be easily modifed in config-overrides.js.
- Changed the first two pages to use antd components instead of vanilla html. 
- Changed the yes/no dropdown on page two to a radio.