### PR TITLE
fixed bug where a select on results page showed defaultvalue

### DIFF
--- a/src/components/PageOne/CompanyInfoForm.js
+++ b/src/components/PageOne/CompanyInfoForm.js
@@ -14,16 +14,17 @@ export default function CompanyInfoForm(props) {
         <div className="form-container">
             <h2>Company Information</h2>
             <Form layout='inline'>
-                <Form.Item wrapperCol={{sm: 24}} style={{width: '30%'}}>
+                <Form.Item wrapperCol={{ sm: 24 }} style={{ width: '30%' }}>
                     <label>Industry</label><br />
                     <Select 
+                        placeholder="Select industry" 
                         value={props.values.industry}
                         onChange={e => props.onChange(e, 'industry')}
                     >
                         {industry.map(entry => <Option value={entry} key={entry}>{entry}</Option>)}
                     </Select>
                 </Form.Item>
-                <Form.Item wrapperCol={{sm: 24}} style={{width: '30%'}}>
+                <Form.Item wrapperCol={{ sm: 24 }} style={{ width: '30%' }}>
                     <label>Annual Turnover (Euro's)</label>
                     <NumericInput 
                         maxLength={25} 
@@ -32,21 +33,21 @@ export default function CompanyInfoForm(props) {
                         onChange={e => props.onChange(e, 'turnover')} 
                     />
                 </Form.Item>
-                <Form.Item wrapperCol={{sm: 24}} style={{width: '30%'}}>
+                <Form.Item wrapperCol={{ sm: 24 }} style={{ width: '30%' }}>
                     <label>Annual Turnover Growth (%)</label>
                     <Slider
-                        style={{width: '250px'}}
+                        style={{ width: '250px' }}
                         value={props.values.turnoverGrowth} 
                         onChange={e => props.onChange(e, 'turnoverGrowth')}
                         tipFormatter={percFormatter} 
                         min={0}
                         max={200}
-                        marks={{0: '0%', 200: '200%'}}
+                        marks={{ 0: '0%', 200: '200%' }}
                     />
                 </Form.Item>
             </Form>
-            <Form layout='inline' style={{marginTop: '3%'}}>
-                <Form.Item wrapperCol={{sm: 24}} style={{width: '30%'}}>
+            <Form layout='inline' style={{ marginTop: '3%' }}>
+                <Form.Item wrapperCol={{ sm: 24 }} style={{ width: '30%' }}>
                     <label>What is your overall profit margin (%)</label>
                     <Slider
                         value={props.values.profitMargin} 

--- a/src/components/Results/OptionsPanel.js
+++ b/src/components/Results/OptionsPanel.js
@@ -51,7 +51,7 @@ export default function OptionsPanel(props) {
                     <Form style={formStyle}>
                         <Form.Item>
                             <label>Industry</label>
-                            <Select defaultValue="Select industry" onChange={e => props.onChange(e, 'industry')}>
+                            <Select value={props.values.industry} onChange={e => props.onChange(e, 'industry')}>
                                 {industry.map(entry => <Option value={entry} key={entry}>{entry}</Option>)}
                             </Select>
                         </Form.Item>

--- a/src/components/Results/ResultsContainer.js
+++ b/src/components/Results/ResultsContainer.js
@@ -50,7 +50,7 @@ class ResultsContainer extends Component {
                     <OptionsContainer />
                 </div>
                 <div className="chart-container">
-                    <div style={{textAlign: 'center'}}>
+                    <div style={{ textAlign: 'center' }}>
                         <Checkbox 
                             onChange={this.onChange}
                             checked={this.state.cumulative}

--- a/src/components/Utils/TextWithTooltip.js
+++ b/src/components/Utils/TextWithTooltip.js
@@ -8,7 +8,7 @@ export default function TextWithTooltip(props) {
     switch (input.position) {
     case 'right':
         return (
-            <div className="label" style={{marginLeft: '5px'}}>
+            <div className="label">
                 <b>{input.text}</b>
                 <Tooltip placement="rightTop" title={input.message}>
                     <Icon type="info-circle" />


### PR DESCRIPTION
Changed the default value to be a placeholder on the turnover select, so that it shows properly when state is loaded from session storage.