### PR TITLE
Feat/medium prio changes

### DIFF
--- a/src/components/PageOne/CompanyInfoForm.js
+++ b/src/components/PageOne/CompanyInfoForm.js
@@ -27,7 +27,9 @@ export default function CompanyInfoForm(props) {
                 <Form.Item wrapperCol={{ sm: 24 }} style={{ width: '30%' }}>
                     <label>Annual Turnover (Euro's)</label>
                     <NumericInput 
-                        maxLength={25} 
+                        maxLength={25}
+                        placeholder="Fill in your revenue" 
+                        tipText="Fill in your revenue"
                         prefix="€" 
                         value={props.values.turnover} 
                         onChange={e => props.onChange(e, 'turnover')} 

--- a/src/components/PageTwo/EmissionsForm.js
+++ b/src/components/PageTwo/EmissionsForm.js
@@ -32,6 +32,8 @@ export default function EmissionsForm(props) {
                         {props.values.emissionsKnown === 'yes'
                             ? <NumericInput
                                 maxLength={25}
+                                placeholder={`Emissions in tons CO\u2082`}
+                                tipText="Enter your emissions"
                                 value={props.values.S1emissions}
                                 onChange={e => props.onChange(e, 'S1emissions')}
                             />
@@ -56,6 +58,8 @@ export default function EmissionsForm(props) {
                     <td>
                         {props.values.emissionsKnown === 'yes'
                             ? <NumericInput
+                                placeholder={`Emissions in tons CO\u2082`}
+                                tipText="Enter your emissions"
                                 maxLength={25}
                                 value={props.values.S2emissions}
                                 onChange={e => props.onChange(e, 'S2emissions')}
@@ -81,6 +85,8 @@ export default function EmissionsForm(props) {
                     <td>
                         {props.values.emissionsKnown === 'yes'
                             ? <NumericInput
+                                placeholder={`Emissions in tons CO\u2082`}
+                                tipText="Enter your emissions"
                                 maxLength={25}
                                 value={props.values.S3emissions}
                                 onChange={e => props.onChange(e, 'S3emissions')}

--- a/src/components/Results/OptionsPanel.js
+++ b/src/components/Results/OptionsPanel.js
@@ -59,6 +59,8 @@ export default function OptionsPanel(props) {
                             <label><b>Annual Turnover (Euro's)</b></label>
                             <NumericInput
                                 maxLength={20}
+                                placeholder="Fill in your revenue" 
+                                tipText="Fill in your revenue"
                                 prefix="€"
                                 value={props.values.turnover}
                                 onChange={e => props.onChange(e, 'turnover')}
@@ -136,6 +138,8 @@ export default function OptionsPanel(props) {
                             {props.values.emissionsKnown === 'yes'
                                 ? <NumericInput
                                     style={emissionStyle}
+                                    placeholder={`Emissions in tons CO\u2082`}
+                                    tipText="Enter your emissions"
                                     maxLength={25}
                                     value={props.values.S1emissions}
                                     onChange={e => props.onChange(e, 'S1emissions')}
@@ -161,6 +165,8 @@ export default function OptionsPanel(props) {
                             {props.values.emissionsKnown === 'yes'
                                 ? <NumericInput
                                     style={emissionStyle}
+                                    placeholder={`Emissions in tons CO\u2082`}
+                                    tipText="Enter your emissions"
                                     maxLength={25}
                                     value={props.values.S2emissions}
                                     onChange={e => props.onChange(e, 'S2emissions')}
@@ -186,6 +192,8 @@ export default function OptionsPanel(props) {
                             {props.values.emissionsKnown === 'yes'
                                 ? <NumericInput
                                     style={emissionStyle}
+                                    placeholder={`Emissions in tons CO\u2082`}
+                                    tipText="Enter your emissions"
                                     maxLength={25}
                                     value={props.values.S3emissions}
                                     onChange={e => props.onChange(e, 'S3emissions')}

--- a/src/components/Results/Results.css
+++ b/src/components/Results/Results.css
@@ -102,10 +102,10 @@
     position: absolute;
     right: 2%;
     top: 0.5%;
-    background: #56ca19;
+    background: #45A848;
     padding: 1em;
     border: none;
-    border-radius: 2em;
+    border-radius: .5em;
     font-size: 90%;
     z-index: 99;
 }

--- a/src/components/Results/Results.css
+++ b/src/components/Results/Results.css
@@ -97,6 +97,24 @@
     margin: 5px;
 }
 
+.ecochain-cta {
+    color: white;
+    position: absolute;
+    right: 2%;
+    top: 0.5%;
+    background: #56ca19;
+    padding: 1em;
+    border: none;
+    border-radius: 2em;
+    font-size: 90%;
+    z-index: 99;
+}
+
+.ecochain-cta:hover {
+    cursor: 'pointer';
+    color: white;
+}
+
 .results-logo {
     display: flex;
     flex-direction: row;

--- a/src/components/Results/ResultsContainer.js
+++ b/src/components/Results/ResultsContainer.js
@@ -177,7 +177,7 @@ class ResultsContainer extends Component {
 
                 </div>
             </div>
-            <a className="ecochain" href="https://ecochain.com">
+            <a className="ecochain" href="https://ecochain.com/carbon-tax-calculator/">
                 <img src={require('../../assets/ecochain.png')} alt="powered by Ecochain" />
             </a>
             <footer>

--- a/src/components/Results/ResultsContainer.js
+++ b/src/components/Results/ResultsContainer.js
@@ -71,7 +71,7 @@ class ResultsContainer extends Component {
                                     onChange={this.onChange}
                                     checked={this.state.cumulative}
                                 >
-                            Cumulative
+                                Cumulative
                                 </Checkbox>
                             </div>
                             <MainChart 

--- a/src/components/Results/ResultsContainer.js
+++ b/src/components/Results/ResultsContainer.js
@@ -60,6 +60,9 @@ class ResultsContainer extends Component {
                 </div>
                 
                 <div className="chart-container">
+                    <a className="ecochain-cta" href="https://ecochain.com/carbon-tax-calculator/">
+                        <b>BECOME FUTURE PROOF</b>
+                    </a>
                     <Tabs style={{marginTop: '1%'}}>
                         <Tabs.TabPane tab="Overview" key="1">
                             <div style={{ 

--- a/src/components/Results/Tables/EmissionsTable.js
+++ b/src/components/Results/Tables/EmissionsTable.js
@@ -51,19 +51,19 @@ export default function TaxperyearTable(props) {
             </thead>
             <tbody>
                 <tr>
-                    <td><b>Scope 1 </b>( <i>in tons CO<sub>2</sub></i> )</td>
+                    <td className="desc-column"><b>Scope 1 </b>( <i>in tons CO<sub>2</sub></i> )</td>
                     {
                         scope1.map(el => <td>{addCommas(el)}</td>)
                     }
                 </tr>
                 <tr>
-                    <td><b>Scope 2 </b>( <i>in tons CO<sub>2</sub></i> )</td>
+                    <td className="desc-column"><b>Scope 2 </b>( <i>in tons CO<sub>2</sub></i> )</td>
                     {
                         scope2.map(el => <td>{addCommas(el)}</td>)
                     }
                 </tr>
                 <tr>
-                    <td><b>Scope 3 </b>( <i>in tons CO<sub>2</sub></i> )</td>
+                    <td className="desc-column"><b>Scope 3 </b>( <i>in tons CO<sub>2</sub></i> )</td>
                     {
                         scope3.map(el => <td>{addCommas(el)}</td>)
                     }

--- a/src/components/Results/Tables/ProfitTable.js
+++ b/src/components/Results/Tables/ProfitTable.js
@@ -36,23 +36,25 @@ export default function profitTable(props) {
             </thead>
             <tbody>
                 <tr>
-                    <td><b>Without tax</b></td>
+                    <td className="desc-column"><b>Without tax</b></td>
                     {
                         noTax.map(el => <td>€{addCommas(el)}</td>)
                     }
                 </tr>
                 <tr>
-                    <td><b>After tax</b></td>
+                    <td className="desc-column"><b>After tax</b></td>
                     {
                         tax.map(el => <td>€{addCommas(el)}</td>)
                     }
                 </tr>
                 <tr>
-                    <td><b>Difference</b></td>{
+                    <td className="desc-column"><b>Impact</b></td>{
                         tax.map((el, index) => {
                             return el - noTax[index]
                         }).map(el => {
-                            return <td>€{addCommas(el)}</td>
+                            return el < 0
+                                ? <td className="negative">€{addCommas(el)}</td>
+                                : <td className="positive">€{addCommas(el)}</td>
                         })
                     } 
                 </tr>

--- a/src/components/Results/Tables/ProfitTable.js
+++ b/src/components/Results/Tables/ProfitTable.js
@@ -48,7 +48,7 @@ export default function profitTable(props) {
                     }
                 </tr>
                 <tr>
-                    <td className="desc-column"><b>Impact</b></td>{
+                    <td className="desc-column"><b>Impact on profit</b></td>{
                         tax.map((el, index) => {
                             return el - noTax[index]
                         }).map(el => {

--- a/src/components/Results/Tables/TaxperyearTable.js
+++ b/src/components/Results/Tables/TaxperyearTable.js
@@ -29,7 +29,7 @@ export default function TaxperyearTable(props) {
             </thead>
             <tbody>
                 <tr>
-                    <td><b>Tax per year</b></td>
+                    <td className="desc-column"><b>Tax per year</b></td>
                     {
                         perYear.map(el => {
                             return <td>€{addCommas(el)}</td>

--- a/src/components/Results/Tables/tables.css
+++ b/src/components/Results/Tables/tables.css
@@ -9,7 +9,7 @@
     padding: 1%;
     border: 1px solid rgb(175, 175, 175);
     color: #40809C;
-    background: rgb(230, 230, 230);
+    background: rgb(255, 255, 255);
 }
 
 .chart-table td {
@@ -28,8 +28,7 @@ td.positive {
 }
 
 td.desc-column {
-    background: rgb(230, 230, 230);
-    color: #40809C;
+    background: rgb(255, 255, 255);
 }
 
 .chart-table th:empty {

--- a/src/components/Results/Tables/tables.css
+++ b/src/components/Results/Tables/tables.css
@@ -9,7 +9,7 @@
     padding: 1%;
     border: 1px solid rgb(175, 175, 175);
     color: #40809C;
-    background: rgba(255, 255, 255, 0.877);
+    background: rgb(230, 230, 230);
 }
 
 .chart-table td {
@@ -17,6 +17,19 @@
     border: 1px solid rgb(175, 175, 175);
     height: 7vh;
     background: rgba(255, 255, 255, 0.877);
+}
+
+td.negative {
+    color: red;
+}
+
+td.positive {
+    color: #45A848;
+}
+
+td.desc-column {
+    background: rgb(230, 230, 230);
+    color: #40809C;
 }
 
 .chart-table th:empty {

--- a/src/components/Results/TaxOptions.js
+++ b/src/components/Results/TaxOptions.js
@@ -4,11 +4,6 @@ import { Checkbox } from 'antd'
 import TextWithTooltip from '../Utils/TextWithTooltip'
 
 export default function TaxOptions(props) {
-    const growthValues = []
-    for (let i = 0.5; i <= 6.5; i += 0.5) {
-        growthValues.push(i)
-    }
-
     return (
         <div className="tax-options">
             <div>

--- a/src/components/Utils/NumericInput.js
+++ b/src/components/Utils/NumericInput.js
@@ -44,7 +44,7 @@ export default class NumericInput extends React.Component {
       const title = value ? (
           <span className="numeric-input-title">{value !== '-' ? formatNumber(value) : '-'}</span>
       ) : (
-          'Input a number'
+          this.props.tipText
       );
       return (
           <Tooltip
@@ -57,7 +57,7 @@ export default class NumericInput extends React.Component {
                   {...this.props}
                   onChange={this.onChange}
                   onBlur={this.onBlur}
-                  placeholder="Input a number"
+                  placeholder={this.props.placeholder}
                   maxLength={this.props.maxLength}
               />
           </Tooltip>

--- a/src/components/Utils/TooltipMessages.js
+++ b/src/components/Utils/TooltipMessages.js
@@ -70,7 +70,7 @@ export const labels = {
     },
     graphEmissions: {
         position: 'graph',
-        text: `Taxable emissions`,
+        text: `Taxable emissions (in tons)`,
         message: <div><p>This graph displayes the total amount of taxable emissions for your company per year</p></div>
     },
     graphProfit: {


### PR DESCRIPTION
- Reverted table styling.
- Made impact numbers appear red when negative.
- Fixed numeric input tips. They're now more descriptive.
- The 'Powered by Ecochain' logo now also links to their calculator.
- Added another CTA button in the top right of the charts panel.