### PR TITLE
Fix/calculate emissions

### DIFF
--- a/src/components/PageOne/CompanyInfoForm.js
+++ b/src/components/PageOne/CompanyInfoForm.js
@@ -29,7 +29,7 @@ export default function CompanyInfoForm(props) {
                     <NumericInput 
                         maxLength={25}
                         placeholder="Fill in your revenue" 
-                        tipText="Fill in your revenue"
+                        tiptext="Fill in your revenue"
                         prefix="€" 
                         value={props.values.turnover} 
                         onChange={e => props.onChange(e, 'turnover')} 

--- a/src/components/PageTwo/EmissionsForm.js
+++ b/src/components/PageTwo/EmissionsForm.js
@@ -33,7 +33,7 @@ export default function EmissionsForm(props) {
                             ? <NumericInput
                                 maxLength={25}
                                 placeholder={`Emissions in tons CO\u2082`}
-                                tipText="Enter your emissions"
+                                tiptext="Enter your emissions"
                                 value={props.values.S1emissions}
                                 onChange={e => props.onChange(e, 'S1emissions')}
                             />
@@ -59,7 +59,7 @@ export default function EmissionsForm(props) {
                         {props.values.emissionsKnown === 'yes'
                             ? <NumericInput
                                 placeholder={`Emissions in tons CO\u2082`}
-                                tipText="Enter your emissions"
+                                tiptext="Enter your emissions"
                                 maxLength={25}
                                 value={props.values.S2emissions}
                                 onChange={e => props.onChange(e, 'S2emissions')}
@@ -86,7 +86,7 @@ export default function EmissionsForm(props) {
                         {props.values.emissionsKnown === 'yes'
                             ? <NumericInput
                                 placeholder={`Emissions in tons CO\u2082`}
-                                tipText="Enter your emissions"
+                                tiptext="Enter your emissions"
                                 maxLength={25}
                                 value={props.values.S3emissions}
                                 onChange={e => props.onChange(e, 'S3emissions')}

--- a/src/components/Results/OptionsContainer.js
+++ b/src/components/Results/OptionsContainer.js
@@ -6,11 +6,13 @@ import { calculateEmissions } from '../../formulas/calculateEmissions/calculateE
 
 class OptionsContainer extends Component {
     onChange = (data, target) => {
-        this.props.updateInput({ [target]: data })
-        
-        if(this.props.emissionsKnown === 'no') {
-            this.props.updateInput(calculateEmissions(this.props.industry, this.props.turnover))
-        }
+        const update = async function() {
+            await this.props.updateInput({ [target]: data })
+            if (this.props.emissionsKnown === 'no') {
+                this.props.updateInput(calculateEmissions(this.props.industry, this.props.turnover))
+            }
+        }.bind(this)
+        update()
     }
 
     onEmissionsKnownChange = (e) => {

--- a/src/components/Results/OptionsPanel.js
+++ b/src/components/Results/OptionsPanel.js
@@ -38,8 +38,6 @@ const rtStyle = {
     width: '30%',
 }
 
-const co2 = <p>Change your CO<sub>2</sub> emissions</p>
-
 const percs = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
 
 export default function OptionsPanel(props) {
@@ -116,7 +114,7 @@ export default function OptionsPanel(props) {
                 </Panel>
             </Collapse>
             <Collapse defaultActiveKey={['1']} style={collapseStyle}>
-                <Panel header={co2} style={panelStyle}>
+                <Panel header={`Change your CO\u2082 emissions`} style={panelStyle}>
                     <TextWithTooltip topic='emissions' className='infoStyle' />
                     <Form style={formStyle} layout="inline">
                         <Form.Item>

--- a/src/components/Results/OptionsPanel.js
+++ b/src/components/Results/OptionsPanel.js
@@ -60,7 +60,7 @@ export default function OptionsPanel(props) {
                             <NumericInput
                                 maxLength={20}
                                 placeholder="Fill in your revenue" 
-                                tipText="Fill in your revenue"
+                                tiptext="Fill in your revenue"
                                 prefix="€"
                                 value={props.values.turnover}
                                 onChange={e => props.onChange(e, 'turnover')}
@@ -139,7 +139,7 @@ export default function OptionsPanel(props) {
                                 ? <NumericInput
                                     style={emissionStyle}
                                     placeholder={`Emissions in tons CO\u2082`}
-                                    tipText="Enter your emissions"
+                                    tiptext="Enter your emissions"
                                     maxLength={25}
                                     value={props.values.S1emissions}
                                     onChange={e => props.onChange(e, 'S1emissions')}
@@ -166,7 +166,7 @@ export default function OptionsPanel(props) {
                                 ? <NumericInput
                                     style={emissionStyle}
                                     placeholder={`Emissions in tons CO\u2082`}
-                                    tipText="Enter your emissions"
+                                    tiptext="Enter your emissions"
                                     maxLength={25}
                                     value={props.values.S2emissions}
                                     onChange={e => props.onChange(e, 'S2emissions')}
@@ -193,7 +193,7 @@ export default function OptionsPanel(props) {
                                 ? <NumericInput
                                     style={emissionStyle}
                                     placeholder={`Emissions in tons CO\u2082`}
-                                    tipText="Enter your emissions"
+                                    tiptext="Enter your emissions"
                                     maxLength={25}
                                     value={props.values.S3emissions}
                                     onChange={e => props.onChange(e, 'S3emissions')}

--- a/src/components/Utils/NumericInput.js
+++ b/src/components/Utils/NumericInput.js
@@ -44,7 +44,7 @@ export default class NumericInput extends React.Component {
       const title = value ? (
           <span className="numeric-input-title">{value !== '-' ? formatNumber(value) : '-'}</span>
       ) : (
-          this.props.tipText
+          this.props.tiptext
       );
       return (
           <Tooltip


### PR DESCRIPTION
- The emissions should now be calculated before the graph is updated instead of after.
- Cleaned up the 3rd options panel header (unnecessary margin).
- Got rid of a react complaint in the console.